### PR TITLE
Improve env handling and cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,10 @@ SMTP_PASSWORD=<smtp password>
 EMAIL_RECIPIENT=<your email>
 ```
 
+The `config` module now loads this file automatically, so simply importing
+`config` ensures all environment variables are available throughout the
+project.
+
 Additional variables such as `WHISPER_API_URL` or `LOCAL_TTS_URL` can be used to point to your local services.  See the code for the full list.
 
 ## Usage

--- a/config.py
+++ b/config.py
@@ -1,6 +1,10 @@
 
 import os
 from pathlib import Path
+from dotenv import load_dotenv
+
+# Load environment once so other modules can simply import config
+load_dotenv()
 
 # TTS Settings
 tts_default_speaker = os.getenv('TTS_SPEAKER', 'p228')

--- a/tts.py
+++ b/tts.py
@@ -1,12 +1,8 @@
 import os
 import json
 import requests
-from dotenv import load_dotenv
 from pathlib import Path
-from config import tts_default_speaker, tts_default_language
-
-# Load environment variables
-load_dotenv()
+from config import tts_default_speaker, tts_default_language  # config loads .env
 
 # Constants
 LOCAL_TTS_URL = os.getenv("LOCAL_TTS_URL", "http://192.168.1.154:5500")

--- a/visuals.py
+++ b/visuals.py
@@ -4,10 +4,6 @@ import time
 import logging
 import requests
 from pathlib import Path
-from dotenv import load_dotenv
-
-# Load environment
-load_dotenv()
 
 # Configure logging
 logging.basicConfig(

--- a/visuals2.py
+++ b/visuals2.py
@@ -4,7 +4,6 @@ import time
 import requests
 import logging
 from pathlib import Path
-from dotenv import load_dotenv
 from urllib.parse import urlparse
 
 # Configure logging
@@ -17,8 +16,6 @@ logging.basicConfig(
     ]
 )
 
-# Load environment variables from .env file
-load_dotenv()
 
 # Configuration
 API_KEY = os.getenv('LEONARDO_API_KEY')


### PR DESCRIPTION
## Summary
- load .env automatically in `config`
- use requests for image upscaling
- close clips in `video_assembler`
- drop individual `load_dotenv` calls
- document automatic env loading in README

## Testing
- `PYTHONUTF8=1 python -m py_compile $(git ls-files '*.py' | grep -v topic_truecrime.py)`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68402ab537048321b126041ba6f8357a