### PR TITLE
Add customizable prompts in web UI

### DIFF
--- a/narration_and_style.py
+++ b/narration_and_style.py
@@ -74,8 +74,16 @@ def select_background_music_via_gpt(topic, music_options):
         return "neutral"
 
 
-def generate_video_script(topic, length, size, num_sections, num_segments,
-                          voice=None, style=None):
+def generate_video_script(
+    topic,
+    length,
+    size,
+    num_sections,
+    num_segments,
+    voice=None,
+    style=None,
+    prompt_template=None,
+):
     try:
         TARGET_MAIN_SEGMENT_DURATION = 4
         TARGET_SEGUE_SEGMENT_DURATION = 2
@@ -161,9 +169,12 @@ def generate_video_script(topic, length, size, num_sections, num_segments,
 
         prompt_json = json.dumps(script_json, indent=4)
 
-        template_path = os.path.join(os.path.dirname(__file__), 'prompt_template.txt')
-        with open(template_path, 'r') as template_file:
-            template = template_file.read()
+        if prompt_template:
+            template = prompt_template
+        else:
+            template_path = os.path.join(os.path.dirname(__file__), 'prompt_template.txt')
+            with open(template_path, 'r') as template_file:
+                template = template_file.read()
         prompt = template.format(length=length, topic=topic, prompt_json=prompt_json,
                                  num_sections=num_sections, num_segments=num_segments)
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -12,12 +12,20 @@
     <h1 class="mb-4">AI Video Generator</h1>
     <form action="/start" method="post">
         <div class="mb-3">
-            <label for="topic" class="form-label">Topic</label>
-            <input type="text" class="form-control" id="topic" name="topic" required>
+            <label for="topic" class="form-label">Topic (leave blank to auto-generate)</label>
+            <input type="text" class="form-control" id="topic" name="topic">
         </div>
         <div class="mb-3">
             <label for="length" class="form-label">Length (seconds)</label>
             <input type="number" class="form-control" id="length" name="length" value="60" min="10" max="300" required>
+        </div>
+        <div class="mb-3">
+            <label for="num_sections" class="form-label">Sections</label>
+            <input type="number" class="form-control" id="num_sections" name="num_sections" value="3" min="1" max="10">
+        </div>
+        <div class="mb-3">
+            <label for="num_segments" class="form-label">Segments per Section</label>
+            <input type="number" class="form-control" id="num_segments" name="num_segments" value="3" min="1" max="12">
         </div>
         <div class="mb-3">
             <label for="voice" class="form-label">Voice</label>
@@ -34,6 +42,14 @@
                 <option value="{{s}}">{{s}}</option>
                 {% endfor %}
             </select>
+        </div>
+        <div class="mb-3">
+            <label for="prompt_template" class="form-label">Script Prompt Template (optional)</label>
+            <textarea class="form-control" id="prompt_template" name="prompt_template" rows="4"></textarea>
+        </div>
+        <div class="mb-3">
+            <label for="topic_prompt" class="form-label">Topic Prompt Template (optional)</label>
+            <textarea class="form-control" id="topic_prompt" name="topic_prompt" rows="3"></textarea>
         </div>
         <button type="submit" class="btn btn-primary">Create Video</button>
     </form>

--- a/web_pipeline.py
+++ b/web_pipeline.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from datetime import datetime
 
 from narration_and_style import generate_video_script
+from topic import generate_topic
 from workflow_utils import generate_and_download_images
 from tts import process_tts
 from video_assembler import assemble_video
@@ -13,8 +14,36 @@ def sanitize(name: str) -> str:
     return "".join(c if c.isalnum() or c in (" ", "_") else "_" for c in name).strip().replace(" ", "_")
 
 
-def run_pipeline(topic: str, length: int, voice: str, style: str) -> str:
-    script = generate_video_script(topic, length, "1080x1920", 3, 3, voice=voice, style=style)
+def run_pipeline(
+    topic: str,
+    length: int,
+    voice: str,
+    style: str,
+    num_sections: int = 3,
+    num_segments: int = 3,
+    prompt_template: str | None = None,
+    topic_prompt: str | None = None,
+) -> str:
+    if not topic and topic_prompt:
+        suggestion = generate_topic(topic_prompt)
+        if suggestion:
+            topic = suggestion["title"]
+            length = suggestion.get("length", length)
+            num_sections = suggestion.get("sections", num_sections)
+            num_segments = suggestion.get("segments_per_section", num_segments)
+        else:
+            raise ValueError("Failed to generate topic from prompt")
+
+    script = generate_video_script(
+        topic,
+        length,
+        "1080x1920",
+        num_sections,
+        num_segments,
+        voice=voice,
+        style=style,
+        prompt_template=prompt_template,
+    )
     script = generate_and_download_images(script)
     script = process_tts(script)
 


### PR DESCRIPTION
## Summary
- allow passing optional prompt template and topic prompt through the web interface
- add form fields for script prompt, topic prompt, sections and segments
- support dynamic prompt templates in `generate_video_script`
- add helper `generate_topic` and improve loading custom prompt in topic generator
- update pipeline and worker to use these new options

## Testing
- `python -m py_compile webapp.py web_pipeline.py narration_and_style.py topic.py`

------
https://chatgpt.com/codex/tasks/task_e_6840bb27a23c8321a7d5173a3f7a67f2